### PR TITLE
Start picker with persisted colorscheme selected

### DIFF
--- a/lua/colorscheme-persist/init.lua
+++ b/lua/colorscheme-persist/init.lua
@@ -91,9 +91,23 @@ end
 
 -- Open telescope picker to change and save colorscheme
 function M.picker()
+  local before_color = M.get_colorscheme()
+  local colors = M.colorschemes or { before_color }
+
+  if not vim.tbl_contains(colors, before_color) then
+    table.insert(colors, 1, before_color)
+  end
+
+  colors = vim.list_extend(
+    { before_color },
+    vim.tbl_filter(function(color)
+      return color ~= before_color
+    end, colors)
+  )
+
   pickers.new(M.picker_opts, {
     prompt_title = "colorschemes",
-    finder = finders.new_table({ results = M.colorschemes }),
+    finder = finders.new_table({ results = colors }),
     sorter = conf.generic_sorter(M.picker_opts),
     attach_mappings = function(prompt_bufnr)
       actions.select_default:replace(function()


### PR DESCRIPTION
The technique used here was adapted from code found in the nvim-telescope/telescope.nvim plugin (specifically, internal.colorscheme() from lua/telescope/builtin/__internal.lua). The currently persisted value is removed from the sorted sequence and placed at the start of the list where it becomes the default selection for the picker.

<img width="1440" alt="Screenshot 2022-12-10 at 9 12 42 PM" src="https://user-images.githubusercontent.com/25421078/206883280-352f96d3-5392-4ffd-8821-8fab3a729546.png">

This allows the user to remind themselves of the currently selected colorscheme by opening the picker and simply hitting the [Enter] key to exit back with effectively nothing changed.