### PR TITLE
Remove colorscheme default setting

### DIFF
--- a/lua/colorscheme-persist/init.lua
+++ b/lua/colorscheme-persist/init.lua
@@ -121,7 +121,9 @@ function M.picker()
         else
           colorscheme = selection[1]
         end
-        vim.cmd("colorscheme default") -- reset settings
+        -- reset settings before setting new colorscheme
+        vim.cmd("hi clear")
+        vim.cmd("syntax reset")
         vim.cmd("colorscheme " .. colorscheme) -- change colorscheme
         -- save
         _save_colorscheme(colorscheme)


### PR DESCRIPTION
This seems to be intended to reset the colorscheme settings, but I notice this causes some of the 'default' colorscheme colors to appear on selected colorschemes( noticed on noctis_azureus & noctis_lux) using `hi clear` && `syntax reset` instead of colorscheme default seem to fix the problem

Feel free to close if you're not interested

Thanks!